### PR TITLE
Fixed argument that broke due to Keras update and improved zero mean subtract module

### DIFF
--- a/transfer_learning_test.py
+++ b/transfer_learning_test.py
@@ -2,7 +2,8 @@ import numpy as np
 from vgg16 import VGG16
 from resnet50 import ResNet50
 from keras.preprocessing import image
-from imagenet_utils import preprocess_input, decode_predictions
+from keras.applications.imagenet_utils import preprocess_input
+from imagenet_utils import decode_predictions
 
 model = VGG16(include_top=True, weights='imagenet')
 

--- a/transfer_learning_vgg16_custom_data.py
+++ b/transfer_learning_vgg16_custom_data.py
@@ -4,7 +4,8 @@ import os
 import time
 from vgg16 import VGG16
 from keras.preprocessing import image
-from imagenet_utils import preprocess_input, decode_predictions
+from keras.applications.imagenet_utils import preprocess_input
+from imagenet_utils import decode_predictions
 from keras.layers import Dense, Activation, Flatten
 from keras.layers import merge, Input
 from keras.models import Model
@@ -33,7 +34,7 @@ for dataset in data_dir_list:
 	img_list=os.listdir(data_path+'/'+ dataset)
 	print ('Loaded the images of dataset-'+'{}\n'.format(dataset))
 	for img in img_list:
-		img_path = data_path + '/'+ dataset + '/'+ img 
+		img_path = data_path + '/'+ dataset + '/'+ img
 		img = image.load_img(img_path, target_size=(224, 224))
 		x = image.img_to_array(img)
 		x = np.expand_dims(x, axis=0)
@@ -62,7 +63,7 @@ labels[404:606]=2
 labels[606:]=3
 
 names = ['cats','dogs','horses','humans']
-	  
+
 # convert class labels to on-hot encoding
 Y = np_utils.to_categorical(labels, num_classes)
 

--- a/vgg16.py
+++ b/vgg16.py
@@ -99,7 +99,7 @@ def VGG16(include_top=True, weights='imagenet',
                                       default_size=224,
                                       min_size=48,
                                       data_format=K.image_data_format(),
-                                      include_top=include_top)
+                                      require_flatten=include_top)
 
     if input_tensor is None:
         img_input = Input(shape=input_shape)


### PR DESCRIPTION
Following your youtube tutorial I encountered an error when using `transfer_learning_test.py`. Seems like one of the functions that  `vgg16.py` uses got updated ( _obtain_input_shape ), so the argument `include_top` was no longer recognized. I changed it to proper one according to the Keras master repo.

Also, I noticed the `prepocess_input` function you used in the tutorial is different from the one that is imported in `vgg16.py` `(from keras.applications.imagenet_utils import preprocess_input`). I downloaded your elephant.jpg picture and fed it to the net using both `prepocess_input` functions:

> Acc  with Anujshah's mean subtraction:
  (u'n01871265', u'tusker', 0.501463), 
  (u'n02504458', u'African_elephant', 0.2179115),
  (u'n02504013', u'Indian_elephant', 0.2033304),
  (u'n02437312', u'Arabian_camel', 0.069142222), 
  (u'n03743016', u'megalith', 0.0050439108)

> Acc  with Keras' mean subtraction:
   (u'n01871265', u'tusker', 0.58339375), 
  (u'n02504013', u'Indian_elephant', 0.19474733), 
  (u'n02504458', u'African_elephant', 0.19219707), 
  (u'n02437312', u'Arabian_camel', 0.02352963), 
  (u'n03743016', u'megalith', 0.0041032545)

I observed a significant improvement in the accuracy when the mean was substracted using the Keras method. Looking at the code in Keras master repo, there is some reference that says these models were ported from Caffe and that the mean is subtracted accordingly. Not entirely sure what is the difference but accuracy-wise is simply better. Hope this hels :)

