### PR TITLE
Fixed _obtain_input_shape error

### DIFF
--- a/vgg16.py
+++ b/vgg16.py
@@ -25,7 +25,7 @@ from keras.utils.data_utils import get_file
 from keras import backend as K
 from keras.applications.imagenet_utils import decode_predictions
 from keras.applications.imagenet_utils import preprocess_input
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 from keras.engine.topology import get_source_inputs
 
 


### PR DESCRIPTION
Keras 2.2 had a minor change.

Before: 
from keras.applications.imagenet_utils import _obtain_input_shape

After:
from keras_applications.imagenet_utils import _obtain_input_shape

The code is working for me after making the change.